### PR TITLE
Fix Tuff Twins exposed butt sprite not showing

### DIFF
--- a/bossbar_data.lua
+++ b/bossbar_data.lua
@@ -518,13 +518,13 @@ HPBars.BossDefinitions = {
 		conditionalSprites = {
 			{
 				function(entity)
-					return entity.Parent == nil and entity:ToNPC().I2 == 1
+					return entity.Parent == nil and entity.Child ~= nil and entity:ToNPC().I2 == 1
 				end,
 				path .. "altpath/tuff_twin_exposed.png"
 			},
 			{
 				function(entity)
-					return entity.Parent ~= nil and entity:ToNPC().I2 == 1
+					return entity.Parent ~= nil and entity.Child ~= nil and entity:ToNPC().I2 == 1
 				end,
 				path .. "altpath/tuff_twin_segment_exposed.png"
 			},


### PR DESCRIPTION
The exposed butt sprite wasn't showing, it was showing the regular exposed segment sprite instead. This was due to not checking for enough things, so I fixed it and it shows properly now.