### PR TITLE
Check spawner entity for Heretic instead of subtype

### DIFF
--- a/bossbar_data.lua
+++ b/bossbar_data.lua
@@ -166,8 +166,8 @@ HPBars.BossIgnoreList = {
 	["903.1"] = function(entity) -- The Mask
 		return string.find(entity:GetSprite():GetAnimation(), "Stun")
 	end,
-	["905.0"] = function(entity) -- Heretic
-		return entity.SubType == 1
+	["905.0"] = function(entity) -- Heretic (fading dummy)
+		return entity.SpawnerEntity ~= nil
 	end,
 	["906.1"] = true, -- hornfel decoy
 	["907.0"] = true, -- Gideon (will be handled by the game itself)


### PR DESCRIPTION
To fix custom champions, since the subtype works fine otherwise