### PR TITLE
fix invalid order function for sorting with lots of lokii's

### DIFF
--- a/bossbar_data.lua
+++ b/bossbar_data.lua
@@ -732,7 +732,7 @@ HPBars.BossDefinitions = {
 		conditionalSprites = {
 			{"isI1Equal", path .. "chapter4/lokii_2.png", {2}}
 		},
-		sorting = function(entity1, entity2) return entity1:ToNPC().I1 == 2 end,
+		sorting = function(entity1, entity2) return entity2:ToNPC().I1 < entity1:ToNPC().I1 end,
 		offset = Vector(-3, 0)
 	},
 	["71.0"] = {sprite = path .. "chapter2/fistula_large.png", bossColors={ "_grey", }, offset = Vector(-7, 0)},


### PR DESCRIPTION
If I'm understanding this correctly, the left face lokii should be sorted to the left and the right face lokii should be sorted to the right. (Correct me if I'm wrong.)

The previous sort function could throw "invalid order function for sorting" in greed mode boss waves where 6 lokii's spawned in and some number of them were killed.